### PR TITLE
Add CartPole MPC

### DIFF
--- a/code_examples/train_mujoco/mpc/train.py
+++ b/code_examples/train_mujoco/mpc/train.py
@@ -13,7 +13,7 @@ from pytorchrl.agent.algorithms import MB_MPC
 from pytorchrl.agent.env import VecEnv
 from pytorchrl.agent.storages import MBReplayBuffer
 from pytorchrl.agent.actors import MBActor
-from pytorchrl.envs.pybullet import pybullet_train_env_factory, pybullet_test_env_factory
+from pytorchrl.envs.mujoco import mujoco_train_env_factory, mujoco_test_env_factory
 from pytorchrl.utils import LoadFromFile, save_argparse, cleanup_log_dir
 
 def main():
@@ -46,7 +46,7 @@ def main():
         # 1. Define Train Vector of Envs
         train_envs_factory, action_space, obs_space = VecEnv.create_factory(vec_env_size=args.num_env_processes,
                                                                             log_dir=args.log_dir,
-                                                                            env_fn=pybullet_train_env_factory,
+                                                                            env_fn=mujoco_train_env_factory,
                                                                             env_kwargs={"env_id": args.env_id,
                                                                                         "frame_skip": args.frame_skip,
                                                                                         "frame_stack": args.frame_stack})
@@ -54,7 +54,7 @@ def main():
         # 2. Define Test Vector of Envs (Optional)
         test_envs_factory, _, _ = VecEnv.create_factory(vec_env_size=args.num_env_processes,
                                                         log_dir=args.log_dir,
-                                                        env_fn=pybullet_test_env_factory,
+                                                        env_fn=mujoco_test_env_factory,
                                                         env_kwargs={"env_id": args.env_id,
                                                                     "frame_skip": args.frame_skip,
                                                                     "frame_stack": args.frame_stack})

--- a/pytorchrl/agent/actors/mb_actor.py
+++ b/pytorchrl/agent/actors/mb_actor.py
@@ -120,7 +120,6 @@ class MBActor(Actor):
         self.hidden_size = hidden_size
 
         self.create_dynamics()
-        print(self.dynamics_model)
 
     @classmethod
     def create_factory(

--- a/pytorchrl/agent/actors/planner/MPC.py
+++ b/pytorchrl/agent/actors/planner/MPC.py
@@ -10,7 +10,7 @@ class MPC():
     """
     def __init__(self, action_space, config, device)-> None:
         if type(action_space) == gym.spaces.discrete.Discrete:
-            self.action_space = 1
+            self.action_space = action_space.n
             self.action_type = "discrete"
             self.action_low = None
             self.action_high = None

--- a/pytorchrl/agent/actors/reward_functions/__init__.py
+++ b/pytorchrl/agent/actors/reward_functions/__init__.py
@@ -1,18 +1,20 @@
-from pytorchrl.agent.actors.reward_functions.gym_reward_functions import pendulum, halfcheetah_mujoco, inverted_pendulum_mujoco
+from pytorchrl.agent.actors.reward_functions.gym_reward_functions import cartpole, pendulum, halfcheetah_mujoco, inverted_pendulum_mujoco
 from pytorchrl.agent.actors.reward_functions.pybullet_reward_functions import halfcheetah_bullet
 """Good Resource of reward functions: https://arxiv.org/pdf/1907.02057.pdf 
     including gym envrionemnts as well as pybullet environments
 """
 
 def get_reward_function(env_id):
-    # gym env
-    if env_id == "Pendulum-v0" or env_id == "Pendulum-v1":
+    # gym envs
+    if env_id == "CartPole-v0" or env_id == "CartPole-v1":
+        return cartpole
+    elif env_id == "Pendulum-v0" or env_id == "Pendulum-v1":
         return pendulum
     elif env_id == "InvertedPendulum-v2":
         return inverted_pendulum_mujoco
     elif env_id == "HalfCheetah-v2" or env_id == "HalfCheetah-v3":
         return halfcheetah_mujoco
-    # pybullet env
+    # pybullet envs
     elif env_id == "HalfCheetahBulletEnv-v0":
         return halfcheetah_bullet
     

--- a/pytorchrl/agent/actors/reward_functions/gym_reward_functions.py
+++ b/pytorchrl/agent/actors/reward_functions/gym_reward_functions.py
@@ -6,6 +6,16 @@ import math
 """
 
 
+def cartpole(state: torch.Tensor, action: torch.Tensor, next_state: torch.Tensor)-> torch.Tensor:
+    """
+    Based on https://arxiv.org/pdf/1907.02057.pdf
+    reward = cos(θ_t) - 0.01x²
+    """
+    x, x_dot, theta, theta_dot = state[:, 0], state[:, 1], state[:, 2], state[:, 3]
+    
+    reward = torch.cos(theta)[:, None] - 0.01 * x**2
+    return reward
+
 def pendulum(state: torch.Tensor, action: torch.Tensor, next_state: torch.Tensor)-> torch.Tensor:
     # Original env reward function seems not to work!
     # max_torque = 2.0

--- a/pytorchrl/agent/actors/reward_functions/gym_reward_functions.py
+++ b/pytorchrl/agent/actors/reward_functions/gym_reward_functions.py
@@ -13,7 +13,7 @@ def cartpole(state: torch.Tensor, action: torch.Tensor, next_state: torch.Tensor
     """
     x, x_dot, theta, theta_dot = state[:, 0], state[:, 1], state[:, 2], state[:, 3]
     
-    reward = torch.cos(theta)[:, None] - 0.01 * x**2
+    reward = torch.cos(theta)[:, None] - 0.01 * x[:, None]**2
     return reward
 
 def pendulum(state: torch.Tensor, action: torch.Tensor, next_state: torch.Tensor)-> torch.Tensor:

--- a/pytorchrl/agent/storages/off_policy/mb_dataset.py
+++ b/pytorchrl/agent/storages/off_policy/mb_dataset.py
@@ -322,6 +322,7 @@ class MBReplayBuffer(S):
                 pass
 
         if type(self.actor.action_space) == gym.spaces.discrete.Discrete:
+
             actions = actions.astype(np.int64)
             actions = np.eye(actions.max()+1)[actions].squeeze(1)
             assert actions.shape == (observations.shape[0], 1, self.actor.action_space.n)

--- a/pytorchrl/agent/storages/off_policy/mb_dataset.py
+++ b/pytorchrl/agent/storages/off_policy/mb_dataset.py
@@ -329,10 +329,10 @@ class MBReplayBuffer(S):
 
         inputs = np.concatenate((observations, actions), axis=-1)
         delta_state = next_observations - observations
-        if self.learn_reward_function:
-            targets = np.concatenate((delta_state, rewards), axis=-1)
-        else:
+        if self.learn_reward_function is not None:
             targets = delta_state
+        else:
+            targets = np.concatenate((delta_state, rewards), axis=-1)
         # watch out inputs have shape (all data, 1, dim) not sure why this extra dim
         inputs = torch.from_numpy(inputs).float().to(self.device).squeeze(1)
         targets = torch.from_numpy(targets).float().to(self.device).squeeze(1)

--- a/pytorchrl/envs/common.py
+++ b/pytorchrl/envs/common.py
@@ -4,6 +4,16 @@ from collections import deque
 import numpy as np
 
 
+class CartPoleActionWrapper(gym.Wrapper):
+    def __init__(self, env):
+        """CartPole expects scalar integer inputs and not numpy array """
+        gym.Wrapper.__init__(self, env)
+
+    def step(self, action):
+        obs, reward, done, info = self.env.step(action[0])
+        return obs, reward, done, info
+
+
 class FrameSkip(gym.Wrapper):
     def __init__(self, env, skip=1):
         """Return only every `skip`-th frame"""

--- a/pytorchrl/envs/mujoco/mujoco_env_factory.py
+++ b/pytorchrl/envs/mujoco/mujoco_env_factory.py
@@ -1,5 +1,5 @@
 import gym
-from pytorchrl.envs.common import FrameStack, FrameSkip, DelayedReward
+from pytorchrl.envs.common import FrameStack, FrameSkip, DelayedReward, CartPoleActionWrapper
 
 
 def mujoco_train_env_factory(env_id, index_col_worker, index_grad_worker, index_env=0, seed=0, frame_skip=0, frame_stack=1, reward_delay=1):
@@ -42,6 +42,9 @@ def mujoco_train_env_factory(env_id, index_col_worker, index_grad_worker, index_
 
     if reward_delay > 1:
         env = DelayedReward(env, delay=reward_delay)
+    
+    if env_id == "CartPole-v0" or env_id == "CartPole-v1":
+        env = CartPoleActionWrapper(env)
 
     return env
 
@@ -85,5 +88,8 @@ def mujoco_test_env_factory(env_id, index_col_worker, index_grad_worker, index_e
 
     if reward_delay > 1:
         env = DelayedReward(env, delay=reward_delay)
+
+    if env_id == "CartPole-v0" or env_id == "CartPole-v1":
+        env = CartPoleActionWrapper(env)
 
     return env


### PR DESCRIPTION
Add CartPole Reward Function and fix bugs. 
Checked performance for the given reward function:
![image](https://user-images.githubusercontent.com/29492081/154282849-9c5bdc5b-6a12-4065-b9e0-9ac2714ea0ef.png)

However, for the option to learn the reward function the agent failed in the same time frame (4k steps).
Could maybe learn it after longer but I think its a problem with the state being theta and not cos(theta). 

> Need state/action preprocessing (e.g. angles to sine and cosine of angle):  when planning in systems with angles, if you expect the angles to wrap around (e.g. a heading that keeps turning left will grow from 0 to 2pi to 4pi), the states here need to be processed before labeled to make equivalent angles matched.

Will test it later but fixing the CP with given reward function should work for now. 
For CartPole I had also to add a wrapper that makes the action input arrays for the environment a single scalar.

Also verified that previous runs with Pendulum and Halfcheetah still perform as before [X]
